### PR TITLE
Fix deprecated data references

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -24,7 +24,7 @@ export class OseActorSheet extends ActorSheet {
   activateEditor(target, editorOptions, initialContent) {
   //_createEditor(target, editorOptions, initialContent) {
     // remove some controls to the editor as the space is lacking
-    if (target == "data.details.description") {
+    if (target == "system.details.description") {
       editorOptions.toolbar = "styleselect bullist hr table removeFormat save";
     }
     super.activateEditor(target, editorOptions, initialContent);
@@ -54,10 +54,10 @@ export class OseActorSheet extends ActorSheet {
     var sortedSpells = {};
     var slots = {};
     for (var i = 0; i < spells.length; i++) {
-      let lvl = spells[i].data.lvl;
+      let lvl = spells[i].system.lvl;
       if (!sortedSpells[lvl]) sortedSpells[lvl] = [];
       if (!slots[lvl]) slots[lvl] = 0;
-      slots[lvl] += spells[i].data.memorized;
+      slots[lvl] += spells[i].system.memorized;
       sortedSpells[lvl].push(spells[i]);
     }
     data.slots = {
@@ -77,7 +77,7 @@ export class OseActorSheet extends ActorSheet {
     event.preventDefault();
     let li = $(event.currentTarget).parents(".item"),
       item = this.actor.getOwnedItem(li.data("item-id")),
-      description = TextEditor.enrichHTML(item.data.data.description);
+      description = TextEditor.enrichHTML(item.system.description);
     // Toggle summary
     if (li.hasClass("expanded")) {
       let summary = li.parents(".item-entry").children(".item-summary");
@@ -98,10 +98,10 @@ export class OseActorSheet extends ActorSheet {
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.getOwnedItem(itemId);
     if (event.target.dataset.field == "cast") {
-      return item.update({ "data.cast": parseInt(event.target.value) });
+      return item.update({ "system.cast": parseInt(event.target.value) });
     } else if (event.target.dataset.field == "memorize") {
       return item.update({
-        "data.memorized": parseInt(event.target.value),
+        "system.memorized": parseInt(event.target.value),
       });
     }
   }
@@ -115,7 +115,7 @@ export class OseActorSheet extends ActorSheet {
       const item = this.actor.getOwnedItem(itemId);
       item.update({
         _id: item.id,
-        "data.cast": item.data.data.memorized,
+        "system.cast": item.system.memorized,
       });
     });
   }
@@ -143,9 +143,9 @@ export class OseActorSheet extends ActorSheet {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.getOwnedItem(li.data("itemId"));
       if (item.type == "weapon") {
-        if (this.actor.data.type === "monster") {
+        if (this.actor.type === "monster") {
           item.update({
-            data: { counter: { value: item.data.data.counter.value - 1 } },
+            data: { counter: { value: item.system.counter.value - 1 } },
           });
         }
         item.rollWeapon({ skipDialog: ev.ctrlKey });
@@ -166,7 +166,7 @@ export class OseActorSheet extends ActorSheet {
       let element = event.currentTarget;
       let attack = element.parentElement.parentElement.dataset.attack;
       const rollData = {
-        actor: this.data,
+        actor: this.actor,
         roll: {},
       };
       actorObject.targetAttack(rollData, attack, {

--- a/module/actor/character-sheet.js
+++ b/module/actor/character-sheet.js
@@ -31,7 +31,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
           initial: "attributes",
         },
       ],
-    });
+    }]);
   }
 
   generateScores() {
@@ -91,7 +91,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   }
 
   _pushLang(table) {
-    const data = this.actor.data.data;
+    const data = this.actor.system;
     let update = duplicate(data[table]);
     this._chooseLang().then((dialogInput) => {
       const name = CONFIG.OSE.languages[dialogInput.choice];
@@ -102,16 +102,16 @@ export class OseActorSheetCharacter extends OseActorSheet {
       }
       let newData = {};
       newData[table] = update;
-      return this.actor.update({ data: newData });
+      return this.actor.update({ "system": newData });
     });
   }
 
   _popLang(table, lang) {
-    const data = this.actor.data.data;
+    const data = this.actor.system;
     let update = data[table].value.filter((el) => el != lang);
     let newData = {};
     newData[table] = { value: update };
-    return this.actor.update({ data: newData });
+    return this.actor.update({ "system": newData });
   }
 
   /* -------------------------------------------- */
@@ -120,7 +120,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
     event.preventDefault();
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.getOwnedItem(itemId);
-    return item.update({ "data.quantity.value": parseInt(event.target.value) });
+    return item.update({ "system.quantity.value": parseInt(event.target.value) });
   }
 
   _onShowModifiers(event) {
@@ -177,22 +177,20 @@ export class OseActorSheetCharacter extends OseActorSheet {
       const itemData = {
         name: `New ${type.capitalize()}`,
         type: type,
-        data: duplicate(header.dataset),
+        system: duplicate(header.dataset),
       };
-      delete itemData.data["type"];
-      return this.actor.createOwnedItem(itemData);
+      delete itemData.system["type"];
+      return this.actor.createEmbeddedDocuments("Item", [itemData]);
     });
 
     //Toggle Equipment
     html.find(".item-toggle").click(async (ev) => {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.getOwnedItem(li.data("itemId"));
-      await this.actor.updateOwnedItem({
+      await this.actor.updateEmbeddedDocuments("Item", [{
         _id: li.data("itemId"),
-        data: {
-          equipped: !item.data.data.equipped,
-        },
-      });
+        "system.equipped": !item.system.equipped
+      }]);
     });
 
     html

--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -7,7 +7,7 @@ export class OseActor extends Actor {
 
   prepareData() {
     super.prepareData();
-    const data = this.data.data;
+    const data = this.system;
 
     // Compute modifiers from actor scores
     this.computeModifiers();
@@ -19,7 +19,7 @@ export class OseActor extends Actor {
     // Determine Initiative
     if (game.settings.get("ose", "initiative") != "group") {
       data.initiative.value = data.initiative.mod;
-      if (this.data.type == "character") {
+      if (this.type == "character") {
         data.initiative.value += data.scores.dex.mod;
       }
     } else {
@@ -31,14 +31,14 @@ export class OseActor extends Actor {
   /*  Socket Listeners and Handlers
     /* -------------------------------------------- */
   getExperience(value, options = {}) {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
     let modified = Math.floor(
-      value + (this.data.data.details.xp.bonus * value) / 100
+      value + (this.system.details.xp.bonus * value) / 100
     );
     return this.update({
-      "data.details.xp.value": modified + this.data.data.details.xp.value,
+      "system.details.xp.value": modified + this.system.details.xp.value,
     }).then(() => {
       const speaker = ChatMessage.getSpeaker({ actor: this });
       ChatMessage.create({
@@ -52,14 +52,14 @@ export class OseActor extends Actor {
   }
 
   isNew() {
-    const data = this.data.data;
-    if (this.data.type == "character") {
+    const data = this.system;
+    if (this.type == "character") {
       let ct = 0;
       Object.values(data.scores).forEach((el) => {
         ct += el.value;
       });
       return ct == 0 ? true : false;
-    } else if (this.data.type == "monster") {
+    } else if (this.type == "monster") {
       let ct = 0;
       Object.values(data.saves).forEach((el) => {
         ct += el.value;
@@ -77,7 +77,7 @@ export class OseActor extends Actor {
       }
     }
     this.update({
-      "data.saves": {
+      "system.saves": {
         death: {
           value: saves.d,
         },
@@ -102,15 +102,10 @@ export class OseActor extends Actor {
   /* -------------------------------------------- */
 
   rollHP(options = {}) {
-    let roll = new Roll(this.data.data.hp.hd).roll();
+    let roll = new Roll(this.system.hp.hd).roll();
     return this.update({
-      data: {
-        actor: this.data,
-        hp: {
-          max: roll.total,
-          value: roll.total,
-        },
-      },
+      "system.hp.max": roll.total,
+      "system.hp.value": roll.total,
     });
   }
 
@@ -119,10 +114,10 @@ export class OseActor extends Actor {
     const rollParts = ["1d20"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "above",
-        target: this.data.data.saves[save].value,
+        target: this.system.saves[save].value,
       },
       details: game.i18n.format("OSE.roll.details.save", { save: label }),
     };
@@ -145,10 +140,10 @@ export class OseActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "below",
-        target: this.data.data.details.morale,
+        target: this.system.details.morale,
       },
     };
 
@@ -169,10 +164,10 @@ export class OseActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "below",
-        target: this.data.data.retainer.loyalty,
+        target: this.system.retainer.loyalty,
       },
     };
 
@@ -192,24 +187,24 @@ export class OseActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "table",
         table: {
           2: game.i18n.format("OSE.reaction.Hostile", {
-            name: this.data.name,
+            name: this.name,
           }),
           3: game.i18n.format("OSE.reaction.Unfriendly", {
-            name: this.data.name,
+            name: this.name,
           }),
           6: game.i18n.format("OSE.reaction.Neutral", {
-            name: this.data.name,
+            name: this.name,
           }),
           9: game.i18n.format("OSE.reaction.Indifferent", {
-            name: this.data.name,
+            name: this.name,
           }),
           12: game.i18n.format("OSE.reaction.Friendly", {
-            name: this.data.name,
+            name: this.name,
           }),
         },
       },
@@ -231,13 +226,13 @@ export class OseActor extends Actor {
 
   rollCheck(score, options = {}) {
     const label = game.i18n.localize(`OSE.scores.${score}.long`);
-    const rollParts = ["1d20", this.data.data.details.level, this.data.data.scores[score].mod];
+    const rollParts = ["1d20", this.system.details.level, this.system.scores[score].mod];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "check",
-        target: this.data.data.scores[score].value,
+        target: this.system.scores[score].value,
       },
 
       details: game.i18n.format("OSE.roll.details.attribute", {
@@ -261,13 +256,13 @@ export class OseActor extends Actor {
 
   rollHitDice(options = {}) {
     const label = game.i18n.localize(`OSE.roll.hd`);
-    const rollParts = [this.data.data.hp.hd];
-    if (this.data.type == "character") {
-      rollParts.push(this.data.data.scores.con.mod);
+    const rollParts = [this.system.hp.hd];
+    if (this.type == "character") {
+      rollParts.push(this.system.scores.con.mod);
     }
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "hitdice",
       },
@@ -289,14 +284,14 @@ export class OseActor extends Actor {
     const rollParts = [];
     let label = "";
     if (options.check == "wilderness") {
-      rollParts.push(this.data.data.details.appearing.w);
+      rollParts.push(this.system.details.appearing.w);
       label = "(2)";
     } else {
-      rollParts.push(this.data.data.details.appearing.d);
+      rollParts.push(this.system.details.appearing.d);
       label = "(1)";
     }
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: {
           type: "appearing",
@@ -321,10 +316,10 @@ export class OseActor extends Actor {
     const rollParts = ["1d6"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "below",
-        target: this.data.data.exploration[expl],
+        target: this.system.exploration[expl],
       },
       details: game.i18n.format("OSE.roll.details.exploration", {
         expl: label,
@@ -346,10 +341,10 @@ export class OseActor extends Actor {
   }
 
   rollDamage(attData, options = {}) {
-    const data = this.data.data;
+    const data = this.system;
 
     const rollData = {
-      actor: this.data,
+      actor: this,
       item: attData.item,
       roll: {
         type: "damage",
@@ -395,11 +390,11 @@ export class OseActor extends Actor {
   }
 
   rollAttack(attData, options = {}) {
-    const data = this.data.data;
+    const data = this.system;
     const rollParts = ["1d20"];
     const dmgParts = [];
     let label = game.i18n.format("OSE.roll.attacks", {
-      name: this.data.name,
+      name: this.name,
     });
     if (!attData.item) {
       dmgParts.push("1d6");
@@ -407,7 +402,7 @@ export class OseActor extends Actor {
       label = game.i18n.format("OSE.roll.attacksWith", {
         name: attData.item.name,
       });
-      dmgParts.push(attData.item.data.damage);
+      dmgParts.push(attData.item.system.damage);
     }
 
     let ascending = game.settings.get("ose", "ascendingAC");
@@ -428,15 +423,15 @@ export class OseActor extends Actor {
         data.scores.str.mod.toString(),
       );
     }
-    if (attData.item && attData.item.data.bonus) {
-      rollParts.push(attData.item.data.bonus);
+    if (attData.item && attData.item.system.bonus) {
+      rollParts.push(attData.item.system.bonus);
     }
     let thac0 = data.thac0.value;
     if (options.type == "melee") {
       ;
     }
     const rollData = {
-      actor: this.data,
+      actor: this,
       item: attData.item,
       roll: {
         type: options.type,
@@ -461,14 +456,14 @@ export class OseActor extends Actor {
 
   async applyDamage(amount = 0, multiplier = 1) {
     amount = Math.floor(parseInt(amount) * multiplier);
-    const hp = this.data.data.hp;
+    const hp = this.system.hp;
 
     // Remaining goes to health
     const dh = Math.clamped(hp.value - amount, 0, hp.max);
 
     // Update the Actor
     return this.update({
-      "data.hp.value": dh,
+      "system.hp.value": dh,
     });
   }
 
@@ -483,39 +478,39 @@ export class OseActor extends Actor {
   }
 
   _isSlow() {
-    this.data.data.isSlow = false;
-    if (this.data.type != "character") {
+    this.system.isSlow = false;
+    if (this.type != "character") {
       return;
     }
-    this.data.items.forEach((item) => {
-      if (item.type == "weapon" && item.data.slow && item.data.equipped) {
-        this.data.data.isSlow = true;
+    this.items.forEach((item) => {
+      if (item.type == "weapon" && item.system.slow && item.system.equipped) {
+        this.system.isSlow = true;
         return;
       }
     });
   }
 
   computeEncumbrance() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
     let option = game.settings.get("ose", "encumbranceOption");
 
     // Compute encumbrance
     let totalWeight = 0;
     let hasItems = false;
-    Object.values(this.data.items).forEach((item) => {
-      if (item.type == "item" && !item.data.treasure) {
+    this.items.forEach((item) => {
+      if (item.type == "item" && !item.system.treasure) {
         hasItems = true;
       }
       if (
         item.type == "item" &&
-        (["complete", "disabled"].includes(option) || item.data.treasure)
+        (["complete", "disabled"].includes(option) || item.system.treasure)
       ) {
-        totalWeight += item.data.quantity.value * item.data.weight;
+        totalWeight += item.system.quantity.value * item.system.weight;
       } else if (option != "basic" && ["weapon", "armor"].includes(item.type)) {
-        totalWeight += item.data.weight;
+        totalWeight += item.system.weight;
       }
     });
     if (option === "detailed" && hasItems) totalWeight += 80;
@@ -537,7 +532,7 @@ export class OseActor extends Actor {
   }
 
   _calculateMovement() {
-    const data = this.data.data;
+    const data = this.system;
     let option = game.settings.get("ose", "encumbranceOption");
     let weight = data.encumbrance.value;
     let delta = data.encumbrance.max - 1600;
@@ -554,13 +549,13 @@ export class OseActor extends Actor {
         data.movement.base = 120;
       }
     } else if (option == "basic") {
-      const armors = this.data.items.filter((i) => i.type == "armor");
+      const armors = this.items.filter((i) => i.type == "armor");
       let heaviest = 0;
       armors.forEach((a) => {
-        if (a.data.equipped) {
-          if (a.data.type == "light" && heaviest == 0) {
+        if (a.system.equipped) {
+          if (a.system.type == "light" && heaviest == 0) {
             heaviest = 1;
-          } else if (a.data.type == "heavy") {
+          } else if (a.system.type == "heavy") {
             heaviest = 2;
           }
         }
@@ -583,23 +578,23 @@ export class OseActor extends Actor {
   }
 
   computeTreasure() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
     // Compute treasure
     let total = 0;
-    let treasure = this.data.items.filter(
-      (i) => i.type == "item" && i.data.treasure
+    let treasure = this.items.filter(
+      (i) => i.type == "item" && i.system.treasure
     );
     treasure.forEach((item) => {
-      total += item.data.quantity.value * item.data.cost;
+      total += item.system.quantity.value * item.system.cost;
     });
     data.treasure = total;
   }
 
   computeAC() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
     // Compute AC
@@ -607,17 +602,17 @@ export class OseActor extends Actor {
     let baseAac = 10;
     let AcShield = 0;
     let AacShield = 0;
-    const data = this.data.data;
+    const data = this.system;
     data.aac.naked = baseAac + data.scores.dex.mod;
     data.ac.naked = baseAc - data.scores.dex.mod;
-    const armors = this.data.items.filter((i) => i.type == "armor");
+    const armors = this.items.filter((i) => i.type == "armor");
     armors.forEach((a) => {
-      if (a.data.equipped && a.data.type != "shield") {
-        baseAc = a.data.ac.value;
-        baseAac = a.data.aac.value;
-      } else if (a.data.equipped && a.data.type == "shield") {
-        AcShield = a.data.ac.value;
-        AacShield = a.data.aac.value;
+      if (a.system.equipped && a.system.type != "shield") {
+        baseAc = a.system.ac.value;
+        baseAac = a.system.aac.value;
+      } else if (a.system.equipped && a.system.type == "shield") {
+        AcShield = a.system.ac.value;
+        AacShield = a.system.aac.value;
       }
     });
     data.aac.value = baseAac + data.scores.dex.mod + AacShield + data.aac.mod;
@@ -627,10 +622,10 @@ export class OseActor extends Actor {
   }
 
   computeModifiers() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
 
     const standard = {
       0: -3,

--- a/module/actor/monster-sheet.js
+++ b/module/actor/monster-sheet.js
@@ -100,7 +100,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     } else {
       link = `@RollTable[${data.id}]`;
     }
-    this.actor.update({ "data.details.treasure.table": link });
+    this.actor.update({ "system.details.treasure.table": link });
   }
   */
   /* -------------------------------------------- */
@@ -138,15 +138,11 @@ export class OseActorSheetMonster extends OseActorSheet {
   }
 
   async _resetCounters(event) {
-    const weapons = this.actor.data.items.filter(i => i.type === 'weapon');
+    const weapons = this.actor.items.filter(i => i.type === 'weapon');
     for (let wp of weapons) {
       const item = this.actor.getOwnedItem(wp._id);
       await item.update({
-        data: {
-          counter: {
-            value: parseInt(wp.data.counter.max),
-          },
-        },
+        "system.counter.value": parseInt(wp.data.counter.max),
       });
     }
   }
@@ -157,11 +153,11 @@ export class OseActorSheetMonster extends OseActorSheet {
     const item = this.actor.getOwnedItem(itemId);
     if (event.target.dataset.field == "value") {
       return item.update({
-        "data.counter.value": parseInt(event.target.value),
+        "system.counter.value": parseInt(event.target.value),
       });
     } else if (event.target.dataset.field == "max") {
       return item.update({
-        "data.counter.max": parseInt(event.target.value),
+        "system.counter.max": parseInt(event.target.value),
       });
     }
   }
@@ -209,12 +205,12 @@ export class OseActorSheetMonster extends OseActorSheet {
         const choices = header.dataset.choices.split(",");
         this._chooseItemType(choices).then((dialogInput) => {
           const itemData = createItem(dialogInput.type, dialogInput.name);
-          this.actor.createOwnedItem(itemData, {});
+          this.actor.createEmbeddedDocuments("Item", [itemData]);
         });
         return;
       }
       const itemData = createItem(type);
-      return this.actor.createOwnedItem(itemData, {});
+      return this.actor.createEmbeddedDocuments("Item", [itemData]);
     });
 
     html.find(".item-reset").click((ev) => {
@@ -250,7 +246,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     html.find(".item-pattern").click(ev => {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.getOwnedItem(li.data("itemId"));
-      let currentColor = item.data.data.pattern;
+      let currentColor = item.system.pattern;
       let colors = Object.keys(CONFIG.OSE.colors);
       let index = colors.indexOf(currentColor);
       if (index + 1 == colors.length) {
@@ -259,7 +255,7 @@ export class OseActorSheetMonster extends OseActorSheet {
         index++;
       }
       item.update({
-        "data.pattern": colors[index]
+        "system.pattern": colors[index]
       })
     });
 

--- a/module/chat.js
+++ b/module/chat.js
@@ -31,7 +31,7 @@ export const addChatMessageContextOptions = function(html, options) {
 export const addChatMessageButtons = function(msg, html, data) {
   // Hide blind rolls
   let blindable = html.find('.blindable');
-  if (msg.data.blind && !game.user.isGM && blindable && blindable.data('blind') === true) {
+  if (msg.blind && !game.user.isGM && blindable && blindable.data('blind') === true) {
     blindable.replaceWith("<div class='dice-roll'><div class='dice-result'><div class='dice-formula'>???</div></div></div>");
   }
   // Buttons

--- a/module/combat.js
+++ b/module/combat.js
@@ -3,7 +3,7 @@ export class OseCombat {
     // Check groups
     data.combatants = [];
     let groups = {};
-    combat.data.combatants.forEach((cbt) => {
+    combat.combatants.forEach((cbt) => {
       groups[cbt.flags.ose.group] = { present: true };
       data.combatants.push(cbt);
     });
@@ -22,7 +22,7 @@ export class OseCombat {
       if (!data.combatants[i].actor) {
         return;
       }
-      if (data.combatants[i].actor.data.data.isSlow) {
+      if (data.combatants[i].actor.system.isSlow) {
         data.combatants[i].initiative = -789;
       } else {
         data.combatants[i].initiative =
@@ -43,7 +43,7 @@ export class OseCombat {
   static async individualInitiative(combat, data) {
     let updates = [];
     let messages = [];
-    combat.data.combatants.forEach((c, i) => {
+    combat.combatants.forEach((c, i) => {
       // This comes from foundry.js, had to remove the update turns thing
       // Roll initiative
       const cf = combat._getInitiativeFormula(c);
@@ -73,8 +73,8 @@ export class OseCombat {
       if (i > 0) chatData.sound = null;   // Only play 1 sound for the whole set
       messages.push(chatData);
     });
-    await combat.updateEmbeddedEntity("Combatant", updates);
-    await CONFIG.ChatMessage.entityClass.create(messages);
+    await combat.updateEmbeddedDocuments("Combatant", updates);
+    await CONFIG.ChatMessage.documentClass.create(messages);
     data.turn = 0;
   }
 
@@ -123,7 +123,7 @@ export class OseCombat {
   static updateCombatant(combat, combatant, data) {
     let init = game.settings.get("ose", "initiative");
     // Why do you reroll ?
-    if (combatant.actor.data.data.isSlow) {
+    if (combatant.actor.system.isSlow) {
       data.initiative = -789;
       return;
     }
@@ -172,7 +172,7 @@ export class OseCombat {
       }
       let data = {};
       OseCombat.rollInitiative(game.combat, data);
-      game.combat.update({ data: data }).then(() => {
+      game.combat.update({ "system": data }).then(() => {
         game.combat.setupTurns();
       });
     });
@@ -181,7 +181,7 @@ export class OseCombat {
   static addCombatant(combat, data, options, id) {
     let token = canvas.tokens.get(data.tokenId);
     let color = "black";
-    switch (token.data.disposition) {
+    switch (token.document.disposition) {
       case -1:
         color = "red";
         break;

--- a/module/dialog/character-creation.js
+++ b/module/dialog/character-creation.js
@@ -122,7 +122,7 @@ export class OseCharacterCreator extends FormApplication {
       stats: this.object.data.stats,
       gold: gold
     }
-    const content = await renderTemplate("/systems/ose/templates/chat/roll-creation.html", templateData)
+    const content = await renderTemplate("/systems/ldlmde/templates/chat/roll-creation.html", templateData)
     ChatMessage.create({
       content: content,
       speaker,
@@ -170,7 +170,7 @@ export class OseCharacterCreator extends FormApplication {
         }
       }
     };
-    this.object.createOwnedItem(itemData);
+    this.object.createEmbeddedDocuments("Item", [itemData]);
   }
   /**
    * This method is called upon form submission after form data is validated

--- a/module/dialog/entity-tweaks.js
+++ b/module/dialog/entity-tweaks.js
@@ -28,8 +28,8 @@ export class OseEntityTweaks extends FormApplication {
    * @return {Object}
    */
   getData() {
-    let data = this.object.data;
-    if (this.object.data.type === 'character') {
+    let data = this.object.system;
+    if (this.object.type === 'character') {
       data.isCharacter = true;
     }
     data.user = game.user;

--- a/module/dialog/party-sheet.js
+++ b/module/dialog/party-sheet.js
@@ -62,7 +62,7 @@ export class OsePartySheet extends FormApplication {
            </div>
         </form>`;
     let pcs = this.object.entities.filter((e) => {
-        return e.getFlag('ose', 'party') && e.data.type == "character";
+        return e.getFlag('ose', 'party') && e.type == "character";
     });
     new Dialog({
       title: "Deal Experience",
@@ -75,12 +75,12 @@ export class OsePartySheet extends FormApplication {
             let toDeal = html.find('input[name="total"]').val();
             // calculate number of shares
             let shares = 0;
-            pcs.forEach(c => {shares += c.data.data.details.xp.share});
+            pcs.forEach(c => {shares += c.system.details.xp.share});
             const value = parseFloat(toDeal) / shares;
             if (value) {
               // Give experience
               pcs.forEach((c) => {
-                c.getExperience(Math.floor(c.data.data.details.xp.share * value));
+                c.getExperience(Math.floor(c.system.details.xp.share * value));
               });
             }
           },

--- a/module/dice.js
+++ b/module/dice.js
@@ -129,10 +129,10 @@ export class OseDice {
     result.target = data.roll.thac0;
 
     const targetAc = data.roll.target
-      ? data.roll.target.actor.data.data.ac.value
+      ? data.roll.target.actor.system.ac.value
       : 9;
     const targetAac = data.roll.target
-      ? data.roll.target.actor.data.data.aac.value
+      ? data.roll.target.actor.system.aac.value
       : 0;
     result.victim = data.roll.target ? data.roll.target.data.name : null;
 

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -13,7 +13,7 @@ export class OseItem extends Item {
   prepareData() {
     // Set default image
     let img = CONST.DEFAULT_TOKEN;
-    switch (this.data.type) {
+    switch (this.type) {
       case "spell":
         img = "/systems/ldlmde/assets/default/spell.png";
         break;
@@ -30,7 +30,7 @@ export class OseItem extends Item {
         img = "/systems/ldlmde/assets/default/item.png";
         break;
     }
-    if (!this.data.img) this.data.img = img;
+    if (!this.img) this.img = img;
     super.prepareData();
   }
 
@@ -40,7 +40,7 @@ export class OseItem extends Item {
   }
 
   getChatData(htmlOptions) {
-    const data = duplicate(this.data.data);
+    const data = duplicate(this.system);
 
     // Rich text description
     data.description = TextEditor.enrichHTML(data.description, htmlOptions);
@@ -49,10 +49,10 @@ export class OseItem extends Item {
     const props = [];
     const labels = this.labels;
 
-    if (this.data.type == "weapon") {
+    if (this.type == "weapon") {
       data.tags.forEach(t => props.push(t.value));
     }
-    if (this.data.type == "spell") {
+    if (this.type == "spell") {
       props.push(`${data.class} ${data.lvl}`, data.range, data.duration);
     }
     if (data.hasOwnProperty("equipped")) {
@@ -65,16 +65,16 @@ export class OseItem extends Item {
   }
 
   rollWeapon(options = {}) {
-    let isNPC = this.actor.data.type != "character";
+    let isNPC = this.actor.type != "character";
     const targets = 5;
-    const data = this.data.data;
+    const data = this.system;
     let type = isNPC ? "attack" : "melee";
     const rollData =
     {
-      item: this.data,
-      actor: this.actor.data,
+      item: this,
+      actor: this.actor,
       roll: {
-        save: this.data.data.save,
+        save: this.system.save,
         target: null
       }
     };
@@ -111,7 +111,7 @@ export class OseItem extends Item {
   }
 
   async rollFormula(options = {}) {
-    const data = this.data.data;
+    const data = this.system;
     if (!data.roll) {
       throw new Error("This Item does not have a formula to roll!");
     }
@@ -122,8 +122,8 @@ export class OseItem extends Item {
     let type = data.rollType;
 
     const newData = {
-      actor: this.actor.data,
-      item: this.data,
+      actor: this.actor,
+      item: this,
       roll: {
         type: type,
         target: data.rollTarget,
@@ -145,9 +145,7 @@ export class OseItem extends Item {
 
   spendSpell() {
     this.update({
-      data: {
-        cast: this.data.data.cast - 1,
-      },
+      "system.cast": this.system.cast - 1,
     }).then(() => {
       this.show({ skipDialog: true });
     });
@@ -163,8 +161,8 @@ export class OseItem extends Item {
       return `<li class='tag'>${fa}${tag}</li>`;
     };
 
-    const data = this.data.data;
-    switch (this.data.type) {
+    const data = this.system;
+    switch (this.type) {
       case "weapon":
         let wTags = formatTag(data.damage, "fa-tint");
         data.tags.forEach((t) => {
@@ -201,7 +199,7 @@ export class OseItem extends Item {
   }
 
   pushTag(values) {
-    const data = this.data.data;
+    const data = this.system;
     let update = [];
     if (data.tags) {
       update = duplicate(data.tags);
@@ -238,16 +236,16 @@ export class OseItem extends Item {
       update = values;
     }
     newData.tags = update;
-    return this.update({ data: newData });
+    return this.update({ "system": newData });
   }
 
   popTag(value) {
-    const data = this.data.data;
+    const data = this.system;
     let update = data.tags.filter((el) => el.value != value);
     let newData = {
       tags: update,
     };
-    return this.update({ data: newData });
+    return this.update({ "system": newData });
   }
 
   roll() {
@@ -259,7 +257,7 @@ export class OseItem extends Item {
         this.spendSpell();
         break;
       case "ability":
-        if (this.data.data.roll) {
+        if (this.system.roll) {
           this.rollFormula();
         } else {
           this.show();
@@ -281,12 +279,12 @@ export class OseItem extends Item {
     const templateData = {
       actor: this.actor,
       tokenId: token ? `${token.scene._id}.${token.id}` : null,
-      item: this.data,
+      item: this,
       data: this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,
       hasDamage: this.hasDamage,
-      isSpell: this.data.type === "spell",
+      isSpell: this.type === "spell",
       hasSave: this.hasSave,
       config: CONFIG.OSE,
     };

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -36,7 +36,7 @@ export class OseItemSheet extends ItemSheet {
   /** @override */
   get template() {
     const path = "systems/ldlmde/templates/items/";
-    return `${path}/${this.item.data.type}-sheet.html`;
+    return `${path}/${this.item.type}-sheet.html`;
   }
 
   /**
@@ -68,11 +68,11 @@ export class OseItemSheet extends ItemSheet {
       this.object.popTag(value);
     });
     html.find('a.melee-toggle').click(() => {
-      this.object.update({data: {melee: !this.object.data.data.melee}});
+      this.object.update({"system.melee": !this.object.system.melee});
     });
 
     html.find('a.missile-toggle').click(() => {
-      this.object.update({data: {missile: !this.object.data.data.missile}});
+      this.object.update({"system.missile": !this.object.system.missile});
     });
 
     super.activateListeners(html);

--- a/module/macros.js
+++ b/module/macros.js
@@ -13,7 +13,7 @@
 export async function createOseMacro(data, slot) {
     if ( data.type !== "Item" ) return;
     if (!( "data" in data ) ) return ui.notifications.warn("You can only create macro buttons for owned Items");
-    const item = data.data;
+    const item = data.system;
   
     // Create the macro command
     const command = `game.ose.rollItemMacro("${item.name}");`;

--- a/ose.js
+++ b/ose.js
@@ -40,8 +40,8 @@ Hooks.once("init", async function () {
   // Register custom system settings
   registerSettings();
 
-  CONFIG.Actor.entityClass = OseActor;
-  CONFIG.Item.entityClass = OseItem;
+  CONFIG.Actor.documentClass = OseActor;
+  CONFIG.Item.documentClass = OseItem;
 
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);
@@ -94,14 +94,14 @@ Hooks.on("renderSidebarTab", async (object, html) => {
     ose.append(` <sub><a href="https://oldschoolessentials.necroticgnome.com/srd/index.php">SRD<a></sub>`);
 
     // License text
-    const template = "systems/ose/templates/chat/license.html";
+    const template = "systems/ldlmde/templates/chat/license.html";
     const rendered = await renderTemplate(template);
     gamesystem.append(rendered);
     
     // User guide
     let docs = html.find("button[data-action='docs']");
     const styling = "border:none;margin-right:2px;vertical-align:middle;margin-bottom:5px";
-    $(`<button data-action="userguide"><img src='/systems/ose/assets/dragon.png' width='16' height='16' style='${styling}'/>My blog</button>`).insertAfter(docs);
+    $(`<button data-action="userguide"><img src='/systems/ldlmde/assets/dragon.png' width='16' height='16' style='${styling}'/>My blog</button>`).insertAfter(docs);
     html.find('button[data-action="userguide"]').click(ev => {
       new FrameViewer('https://dmgamboa.blogspot.com', {resizable: true}).render(true);
     });

--- a/system.json
+++ b/system.json
@@ -2,13 +2,17 @@
   "name": "ldlmde",
   "title": "Leyendas de la Marca del Este",
   "description": "Implementación del sistema de juego Leyendas de la Marca del Este para Foundry Virtual Tabletop.",
-  "version": "1.0.7",
-  "minimumCoreVersion": "0.7.5",
-  "compatibleCoreVersion": "0.7.9",
+  "version": "2.0.0",
+  "minimumCoreVersion": "12",
+  "compatibleCoreVersion": "12",
   "templateVersion": 1,
   "author": "Sergio Cotelo",
-  "esmodules": ["ose.js"],
-  "styles": ["ose.css"],
+  "esmodules": [
+    "ose.js"
+  ],
+  "styles": [
+    "ose.css"
+  ],
   "packs": [],
   "languages": [
     {
@@ -17,14 +21,18 @@
       "path": "lang/en.json"
     },
     {
-  	"lang": "es",
-    "name": "Spanish",
-    "path": "lang/es.json"
+      "lang": "es",
+      "name": "Spanish",
+      "path": "lang/es.json"
     }
   ],
   "gridDistance": 1.5,
   "gridUnits": "m",
   "url": "https://github.com/serxoz/ldlmde/",
   "manifest": "https://raw.githubusercontent.com/serxoz/ldlmde/main/system.json",
-  "download": "https://github.com/serxoz/ldlmde/archive/1.0.7.zip"
+  "download": "https://github.com/serxoz/ldlmde/archive/2.0.0.zip",
+  "compatibility": {
+    "minimum": "12",
+    "verified": "12"
+  }
 }

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -12,7 +12,7 @@
     <a class="item" data-tab="abilities">
       {{localize "OSE.category.abilities"}}
     </a>
-    {{#if data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <a class="item" data-tab="spells">
       {{localize "OSE.category.spells"}}
     </a>
@@ -33,7 +33,7 @@
     <div class="tab" data-group="primary" data-tab="abilities">
       {{> "systems/ldlmde/templates/actors/partials/character-abilities-tab.html"}}
     </div>
-    {{#if data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
       {{> "systems/ldlmde/templates/actors/partials/character-spells-tab.html"}}
     </div>

--- a/templates/actors/dialogs/character-creation.html
+++ b/templates/actors/dialogs/character-creation.html
@@ -5,7 +5,7 @@
             <div data-score="{{id}}" class="form-group">
                 <label><a class="score-roll"><i class="fas fa-dice"></i></a> {{score}}</label>
                 <div class="form-fields">
-                    <input class="score-value" name="data.scores.{{id}}.value" type="text" value="0" data-dtype="Number"/>
+                    <input class="score-value" name="system.scores.{{id}}.value" type="text" value="0" data-dtype="Number"/>
                 </div>
             </div>
             {{/each}}

--- a/templates/actors/dialogs/modifiers-dialog.html
+++ b/templates/actors/dialogs/modifiers-dialog.html
@@ -3,10 +3,10 @@
     <label>{{localize 'OSE.scores.str.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.Melee'}} ({{mod data.scores.str.mod}})
+        {{localize 'OSE.Melee'}} ({{mod system.scores.str.mod}})
       </li>
       <li>
-        {{localize 'OSE.exploration.od.long'}} ({{data.exploration.odMod}} in 6)
+        {{localize 'OSE.exploration.od.long'}} ({{system.exploration.odMod}} in 6)
       </li>
     </ol>
   </div>
@@ -14,10 +14,10 @@
     <label>{{localize 'OSE.scores.int.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.SpokenLanguages'}} ({{localize data.languages.spoken}})
+        {{localize 'OSE.SpokenLanguages'}} ({{localize system.languages.spoken}})
       </li>
       <li>
-        {{localize 'OSE.Literacy'}} ({{localize data.languages.literacy}})
+        {{localize 'OSE.Literacy'}} ({{localize system.languages.literacy}})
       </li>
     </ol>
   </div>
@@ -25,7 +25,7 @@
     <label>{{localize 'OSE.scores.wis.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.saves.magic.long'}} ({{mod data.scores.wis.mod}})
+        {{localize 'OSE.saves.magic.long'}} ({{mod system.scores.wis.mod}})
       </li>
     </ol>
   </div>
@@ -33,13 +33,13 @@
     <label>{{localize 'OSE.scores.dex.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.Missile'}} ({{mod data.scores.dex.mod}})
+        {{localize 'OSE.Missile'}} ({{mod system.scores.dex.mod}})
       </li>
       <li>
-        {{localize 'OSE.Initiative'}} ({{mod data.scores.dex.init}})
+        {{localize 'OSE.Initiative'}} ({{mod system.scores.dex.init}})
       </li>
       <li>
-        {{localize 'OSE.ArmorClass'}} ({{mod data.scores.dex.mod}})
+        {{localize 'OSE.ArmorClass'}} ({{mod system.scores.dex.mod}})
       </li>
     </ol>
   </div>
@@ -47,7 +47,7 @@
     <label>{{localize 'OSE.scores.con.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.Health'}} ({{mod data.scores.con.mod}})
+        {{localize 'OSE.Health'}} ({{mod system.scores.con.mod}})
       </li>
     </ol>
   </div>
@@ -55,13 +55,13 @@
     <label>{{localize 'OSE.scores.cha.long'}}</label>
     <ol>
       <li>
-        {{localize 'OSE.NPCReaction'}} ({{mod data.scores.cha.npc}})
+        {{localize 'OSE.NPCReaction'}} ({{mod system.scores.cha.npc}})
       </li>
       <li>
-        {{localize 'OSE.RetainersMax'}} ({{add data.scores.cha.mod 4}})
+        {{localize 'OSE.RetainersMax'}} ({{add system.scores.cha.mod 4}})
       </li>
       <li>
-        {{localize 'OSE.Loyalty'}} ({{add data.scores.cha.mod 7}})
+        {{localize 'OSE.Loyalty'}} ({{add system.scores.cha.mod 7}})
       </li>
     </ol>
   </div>

--- a/templates/actors/dialogs/tweaks-dialog.html
+++ b/templates/actors/dialogs/tweaks-dialog.html
@@ -2,21 +2,21 @@
   <div class="form-group">
     <label for="spellcaster">{{localize "OSE.Spellcaster"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.spells.enabled" id="spellcaster" {{checked
-          data.spells.enabled}} data-dtype="Boolean" />
+      <input type="checkbox" name="system.spells.enabled" id="spellcaster" {{checked
+          system.spells.enabled}} data-dtype="Boolean" />
     </div>
   </div>
   <div class="form-group">
     <label for="retainer">{{localize "OSE.Retainer"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.retainer.enabled" id="retainer" {{checked
-          data.retainer.enabled}}  data-dtype="Boolean"/>
+      <input type="checkbox" name="system.retainer.enabled" id="retainer" {{checked
+          system.retainer.enabled}}  data-dtype="Boolean"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "OSE.InitiativeBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.initiative.mod" id="initiative" value="{{data.initiative.mod}}"
+      <input type="text" name="system.initiative.mod" id="initiative" value="{{system.initiative.mod}}"
         data-dtype="Number" />
     </div>
   </div>
@@ -24,31 +24,31 @@
   <div class="form-group">
     <label>{{localize "OSE.details.experience.next"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.next" id="experiencenext" value="{{data.details.xp.next}}" data-dtype="Number" />
+      <input type="text" name="system.details.xp.next" id="experiencenext" value="{{system.details.xp.next}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "OSE.details.experience.bonus"}} (%)</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.bonus" id="experience" value="{{data.details.xp.bonus}}" data-dtype="Number"/>
+      <input type="text" name="system.details.xp.bonus" id="experience" value="{{system.details.xp.bonus}}" data-dtype="Number"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "OSE.details.experience.share"}} (%)</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.share" id="experience-share" value="{{data.details.xp.share}}" data-dtype="Number"/>
+      <input type="text" name="system.details.xp.share" id="experience-share" value="{{system.details.xp.share}}" data-dtype="Number"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "OSE.MeleeBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.thac0.mod.melee" id="melee" value="{{data.thac0.mod.melee}}" data-dtype="Number" />
+      <input type="text" name="system.thac0.mod.melee" id="melee" value="{{system.thac0.mod.melee}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "OSE.MissileBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.thac0.mod.missile" id="missile" value="{{data.thac0.mod.missile}}"
+      <input type="text" name="system.thac0.mod.missile" id="missile" value="{{system.thac0.mod.missile}}"
         data-dtype="Number" />
     </div>
   </div>
@@ -56,10 +56,10 @@
     <label>{{localize "OSE.ArmorClassBonus"}}</label>
     <div class="form-fields">
       {{#if config.ascending}}
-      <input type="text" name="data.aac.mod" id="ac" value="{{data.aac.mod}}"
+      <input type="text" name="system.aac.mod" id="ac" value="{{system.aac.mod}}"
         data-dtype="Number" />
       {{else}}
-      <input type="text" name="data.ac.mod" id="ac" value="{{data.ac.mod}}"
+      <input type="text" name="system.ac.mod" id="ac" value="{{system.ac.mod}}"
         data-dtype="Number" />
         {{/if}}
     </div>
@@ -67,15 +67,15 @@
   <div class="form-group">
     <label>{{localize "OSE.Encumbrance"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.encumbrance.max" id="encumbrance" value="{{data.encumbrance.max}}"
+      <input type="text" name="system.encumbrance.max" id="encumbrance" value="{{system.encumbrance.max}}"
         data-dtype="Number" {{#unless user.isGM}}disabled{{/unless}} />
     </div>
   </div>
   <div class="form-group">
     <label for="movementAuto">{{localize "OSE.Setting.MovementAuto"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.config.movementAuto" id="movementAuto" {{checked
-          data.config.movementAuto}}  data-dtype="Boolean" {{#unless user.isGM}}disabled{{/unless}} />
+      <input type="checkbox" name="system.config.movementAuto" id="movementAuto" {{checked
+          system.config.movementAuto}}  data-dtype="Boolean" {{#unless user.isGM}}disabled{{/unless}} />
     </div>
   </div>
   {{/if}}

--- a/templates/actors/monster-sheet.html
+++ b/templates/actors/monster-sheet.html
@@ -9,7 +9,7 @@
     <a class="item" data-tab="attributes">
       {{localize "OSE.category.attributes"}}
     </a>
-    {{#if data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <a class="item" data-tab="spells">
       {{localize "OSE.category.spells"}}
     </a>
@@ -24,7 +24,7 @@
     <div class="tab" data-group="primary" data-tab="attributes">
       {{> "systems/ldlmde/templates/actors/partials/monster-attributes-tab.html"}}
     </div>
-    {{#if data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
       {{> "systems/ldlmde/templates/actors/partials/character-spells-tab.html"}}
     </div>
@@ -33,7 +33,7 @@
       <div class="inventory">
         <div class="item-titles">{{localize "OSE.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="320">
-          {{editor content=data.details.biography target="data.details.biography"
+          {{editor content=system.details.biography target="system.details.biography"
           button=true owner=owner editable=editable}}
         </div>
       </div>

--- a/templates/actors/partials/character-abilities-tab.html
+++ b/templates/actors/partials/character-abilities-tab.html
@@ -12,7 +12,7 @@
     {{#each abilities as |item|}}
     <li class="item-entry">
       <div class="item flexrow" data-item-id="{{item._id}}">
-        <div class="item-name {{#if item.data.roll}}item-rollable{{/if}} flexrow">
+        <div class="item-name {{#if item.system.roll}}item-rollable{{/if}} flexrow">
           <div class="item-image" style="background-image: url({{item.img}})"></div>
           <a>
             <h4 title="{{item.name}}">

--- a/templates/actors/partials/character-attributes-tab.html
+++ b/templates/actors/partials/character-attributes-tab.html
@@ -11,101 +11,101 @@
         <ul class="attributes">
             <li class="attribute ability-score" data-score="str">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.str.check" data-dtype="Boolean" {{checked data.scores.str.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.str.check" data-dtype="Boolean" {{checked system.scores.str.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.str.long' }}">
                     <a>{{ localize "OSE.scores.str.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.str.value" type="text" value="{{data.scores.str.value}}" placeholder="0"
+                    <input name="system.scores.str.value" type="text" value="{{system.scores.str.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.str.mod" type="text" value="{{data.scores.str.mod}}" placeholder="0"
+                    <input name="system.scores.str.mod" type="text" value="{{system.scores.str.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
             <li class="attribute ability-score" data-score="int">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.int.check" data-dtype="Boolean" {{checked data.scores.int.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.int.check" data-dtype="Boolean" {{checked system.scores.int.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.int.long' }}">
                     <a>{{ localize "OSE.scores.int.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.int.value" type="text" value="{{data.scores.int.value}}" placeholder="0"
+                    <input name="system.scores.int.value" type="text" value="{{system.scores.int.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.int.mod" type="text" value="{{data.scores.int.mod}}" placeholder="0"
+                    <input name="system.scores.int.mod" type="text" value="{{system.scores.int.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
             <li class="attribute ability-score" data-score="wis">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.wis.check" data-dtype="Boolean" {{checked data.scores.wis.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.wis.check" data-dtype="Boolean" {{checked system.scores.wis.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.wis.long' }}">
                     <a>{{ localize "OSE.scores.wis.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.wis.value" type="text" value="{{data.scores.wis.value}}" placeholder="0"
+                    <input name="system.scores.wis.value" type="text" value="{{system.scores.wis.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.wis.mod" type="text" value="{{data.scores.wis.mod}}" placeholder="0"
+                    <input name="system.scores.wis.mod" type="text" value="{{system.scores.wis.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
             <li class="attribute ability-score" data-score="dex">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.dex.check" data-dtype="Boolean" {{checked data.scores.dex.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.dex.check" data-dtype="Boolean" {{checked system.scores.dex.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.dex.long' }}">
                     <a>{{ localize "OSE.scores.dex.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.dex.value" type="text" value="{{data.scores.dex.value}}" placeholder="0"
+                    <input name="system.scores.dex.value" type="text" value="{{system.scores.dex.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.dex.mod" type="text" value="{{data.scores.dex.mod}}" placeholder="0"
+                    <input name="system.scores.dex.mod" type="text" value="{{system.scores.dex.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
             <li class="attribute ability-score" data-score="con">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.con.check" data-dtype="Boolean" {{checked data.scores.con.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.con.check" data-dtype="Boolean" {{checked system.scores.con.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.con.long' }}">
                     <a>{{ localize "OSE.scores.con.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.con.value" type="text" value="{{data.scores.con.value}}" placeholder="0"
+                    <input name="system.scores.con.value" type="text" value="{{system.scores.con.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.con.mod" type="text" value="{{data.scores.con.mod}}" placeholder="0"
+                    <input name="system.scores.con.mod" type="text" value="{{system.scores.con.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
             <li class="attribute ability-score" data-score="cha">
                 <div class="attribute-check">
-                    <input class="checkbox-round" type="checkbox" name="data.scores.cha.check" data-dtype="Boolean" {{checked data.scores.cha.check}}/>
+                    <input class="checkbox-round" type="checkbox" name="system.scores.cha.check" data-dtype="Boolean" {{checked system.scores.cha.check}}/>
                 </div>
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.scores.cha.long' }}">
                     <a>{{ localize "OSE.scores.cha.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.cha.value" type="text" value="{{data.scores.cha.value}}" placeholder="0"
+                    <input name="system.scores.cha.value" type="text" value="{{system.scores.cha.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 <div class="attribute-bonus">
-                    <input name="data.scores.cha.mod" type="text" value="{{data.scores.cha.mod}}" placeholder="0"
+                    <input name="system.scores.cha.mod" type="text" value="{{system.scores.cha.mod}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
-            {{#if data.retainer.enabled}}
+            {{#if system.retainer.enabled}}
             <li class="attribute ability-score" data-stat="lr">
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.Loyalty' }}">
                     <a>{{ localize "OSE.LoyaltyShort" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.retainer.loyalty" type="text" value="{{data.retainer.loyalty}}" placeholder="0"
+                    <input name="system.retainer.loyalty" type="text" value="{{system.retainer.loyalty}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -116,25 +116,25 @@
     <div class="resources">
         <div class="flexrow">
             <div class="health">
-                <input class="health-value health-top" name="data.hp.value" type="text" value="{{data.hp.value}}"
+                <input class="health-value health-top" name="system.hp.value" type="text" value="{{system.hp.value}}"
                     data-dtype="Number" placeholder="0" title="{{localize 'OSE.Health'}}" />
-                <input class="health-value health-bottom" name="data.hp.max" type="text" value="{{data.hp.max}}"
+                <input class="health-value health-bottom" name="system.hp.max" type="text" value="{{system.hp.max}}"
                     data-dtype="Number" placeholder="0" title="{{localize 'OSE.HealthMax'}}" />
-                <div class="health-empty" style="height:{{counter false data.hp.value data.hp.max}}%"></div>
-                <div class="health-full" style="height:{{counter true data.hp.value data.hp.max}}%"></div>
+                <div class="health-empty" style="height:{{counter false system.hp.value system.hp.max}}%"></div>
+                <div class="health-full" style="height:{{counter true system.hp.value system.hp.max}}%"></div>
             </div>
             <div class="health armor-class">
                 {{#if config.ascendingAC}}
-                <div class="health-value health-top" title="{{localize 'OSE.ArmorClass'}}">{{data.aac.value}}</div>
+                <div class="health-value health-top" title="{{localize 'OSE.ArmorClass'}}">{{system.aac.value}}</div>
                 <div class="health-value health-bottom" title="{{localize 'OSE.ArmorClassNaked'}}">
-                    {{data.aac.naked}}</div>
-                    {{#if data.aac.shield}}<div class="shield" title="{{localize 'OSE.items.hasShield'}} ({{data.aac.shield}})"><i
+                    {{system.aac.naked}}</div>
+                    {{#if system.aac.shield}}<div class="shield" title="{{localize 'OSE.items.hasShield'}} ({{system.aac.shield}})"><i
                             class="fas fa-shield-alt"></i></div>{{/if}}
                 {{else}}
-                <div class="health-value health-top" title="{{localize 'OSE.ArmorClass'}}">{{data.ac.value}}</div>
+                <div class="health-value health-top" title="{{localize 'OSE.ArmorClass'}}">{{system.ac.value}}</div>
                 <div class="health-value health-bottom" title="{{localize 'OSE.ArmorClassNaked'}}">
-                    {{data.ac.naked}}</div>
-                    {{#if data.ac.shield}}<div class="shield" title="{{localize 'OSE.items.hasShield'}} ({{data.ac.shield}})"><i
+                    {{system.ac.naked}}</div>
+                    {{#if system.ac.shield}}<div class="shield" title="{{localize 'OSE.items.hasShield'}} ({{system.ac.shield}})"><i
                             class="fas fa-shield-alt"></i></div>{{/if}}
                 {{/if}}
             </div>
@@ -146,7 +146,7 @@
                         <a>{{ localize "OSE.HitDiceShort" }}</a>
                     </h4>
                     <div class="attribute-value">
-                        <input name="data.hp.hd" type="text" value="{{data.hp.hd}}" placeholder=""
+                        <input name="system.hp.hd" type="text" value="{{system.hp.hd}}" placeholder=""
                             data-dtype="String" />
                     </div>
                 </li>
@@ -155,8 +155,8 @@
                     <h4 class="attribute-name box-title" title="{{ localize 'OSE.Initiative' }}">
                         {{ localize "OSE.InitiativeShort" }}</h4>
                     <div class="attribute-value"
-                        title="{{localize 'OSE.scores.dex.long'}}({{data.scores.dex.init}}) + {{localize 'OSE.Modifier'}}({{data.initiative.mod}})">
-                        {{add data.scores.dex.init data.initiative.mod}}
+                        title="{{localize 'OSE.scores.dex.long'}}({{system.scores.dex.init}}) + {{localize 'OSE.Modifier'}}({{system.initiative.mod}})">
+                        {{add system.scores.dex.init system.initiative.mod}}
                     </div>
                 </li>
                 {{/if}}
@@ -169,8 +169,8 @@
                         <a>{{localize 'OSE.MeleeShort'}}</a></h4>
                     <div class="flexrow">
                         <div class="attribute-value"
-                            title="{{localize 'OSE.scores.str.long'}}({{data.scores.str.mod}}) + {{localize 'OSE.Modifier'}}({{data.thac0.mod.melee}})">
-                            {{add data.scores.str.mod data.thac0.mod.melee}}
+                            title="{{localize 'OSE.scores.str.long'}}({{system.scores.str.mod}}) + {{localize 'OSE.Modifier'}}({{system.thac0.mod.melee}})">
+                            {{add system.scores.str.mod system.thac0.mod.melee}}
                         </div>
                     </div>
                 </li>
@@ -180,7 +180,7 @@
                     </h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            <input name="data.thac0.bba" type="text" value="{{data.thac0.bba}}" placeholder="0"
+                            <input name="system.thac0.bba" type="text" value="{{system.thac0.bba}}" placeholder="0"
                                 data-dtype="Number" />
                         </div>
                     </div>
@@ -191,7 +191,7 @@
                     </h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            <input name="data.thac0.value" type="text" value="{{data.thac0.value}}" placeholder="0"
+                            <input name="system.thac0.value" type="text" value="{{system.thac0.value}}" placeholder="0"
                                 data-dtype="Number" />
                         </div>
                     </div>
@@ -202,8 +202,8 @@
                         <a>{{localize 'OSE.MissileShort'}}</a></h4>
                     <div class="flexrow">
                         <div class="attribute-value"
-                            title="{{localize 'OSE.scores.dex.long'}}({{data.scores.dex.mod}}) + {{localize 'OSE.Modifier'}}({{data.thac0.mod.missile}})">
-                            {{add data.scores.dex.mod data.thac0.mod.missile}}
+                            title="{{localize 'OSE.scores.dex.long'}}({{system.scores.dex.mod}}) + {{localize 'OSE.Modifier'}}({{system.thac0.mod.missile}})">
+                            {{add system.scores.dex.mod system.thac0.mod.missile}}
                         </div>
                     </div>
                 </li>
@@ -216,7 +216,7 @@
                         {{localize 'OSE.movement.overland.short'}}</h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            {{divide data.movement.base 5}}
+                            {{divide system.movement.base 5}}
                         </div>
                     </div>
                 </li>
@@ -224,8 +224,8 @@
                     <h4 class="attribute-name box-title" title="{{ localize 'OSE.movement.exploration.long' }}">
                         {{ localize "OSE.movement.exploration.short" }}</h4>
                     <div class="attribute-value flexrow">
-                        <input name="data.movement.base" type="text" value="{{data.movement.base}}" placeholder="0"
-                            data-dtype="Number" {{#if data.config.movementAuto}}disabled{{/if}} />
+                        <input name="system.movement.base" type="text" value="{{system.movement.base}}" placeholder="0"
+                            data-dtype="Number" {{#if system.config.movementAuto}}disabled{{/if}} />
                     </div>
                 </li>
                 <li class="attribute attribute-secondaries">
@@ -233,7 +233,7 @@
                         {{localize 'OSE.movement.encounter.short'}}</h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            {{divide data.movement.base 3}}
+                            {{divide system.movement.base 3}}
                         </div>
                     </div>
                 </li>

--- a/templates/actors/partials/character-header.html
+++ b/templates/actors/partials/character-header.html
@@ -4,42 +4,42 @@
     <input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'OSE.details.name'}}" data-dtype="String" />
   </h1>
   <ul class="summary flexrow">
-    {{#if data.retainer.enabled}}
+    {{#if system.retainer.enabled}}
     <li>
-      <input type="text" name="data.retainer.wage" value="{{data.retainer.wage}}" data-dtype="String"
+      <input type="text" name="system.retainer.wage" value="{{system.retainer.wage}}" data-dtype="String"
          />
       <label>{{localize 'OSE.RetainerWage'}}</label>
     </li>
     {{else}}
     <li>
-      <input type="text" name="data.details.title" value="{{data.details.title}}" data-dtype="String"
+      <input type="text" name="system.details.title" value="{{system.details.title}}" data-dtype="String"
          />
       <label>{{localize 'OSE.details.title'}}</label>
     </li>
     {{/if}}
     <li>
-      <input type="text" name="data.details.alignment" value="{{data.details.alignment}}" data-dtype="String"
+      <input type="text" name="system.details.alignment" value="{{system.details.alignment}}" data-dtype="String"
          />
       <label>{{localize 'OSE.details.alignment'}}</label>
     </li>
   </ul>
   <ul class="summary flexrow">
     <li class="flex3">
-      <input type="text" name="data.details.class" value="{{data.details.class}}" data-dtype="String"
+      <input type="text" name="system.details.class" value="{{system.details.class}}" data-dtype="String"
         />
       <label>{{localize 'OSE.details.class'}}</label>
     </li>
-    <li class="{{#if (gt data.details.xp.value data.details.xp.next)}}notify{{/if}}">
-      <input type="text" name="data.details.level" value="{{data.details.level}}" data-dtype="Number"
+    <li class="{{#if (gt system.details.xp.value system.details.xp.next)}}notify{{/if}}">
+      <input type="text" name="system.details.level" value="{{system.details.level}}" data-dtype="Number"
          />
       <label>{{localize 'OSE.details.level'}}</label>
     </li>
     <li class="flex2">
-      <input type="text" name="data.details.xp.value" value="{{data.details.xp.value}}" data-dtype="Number"
+      <input type="text" name="system.details.xp.value" value="{{system.details.xp.value}}" data-dtype="Number"
          />
       <label>{{localize 'OSE.details.experience.base'}}</label>
-      {{#if data.details.xp.bonus}}
-      <span class="xp-bonus">+{{data.details.xp.bonus}}%</span>
+      {{#if system.details.xp.bonus}}
+      <span class="xp-bonus">+{{system.details.xp.bonus}}%</span>
       {{/if}}
     </li>
   </ul>

--- a/templates/actors/partials/character-inventory-tab.html
+++ b/templates/actors/partials/character-inventory-tab.html
@@ -23,12 +23,12 @@
             </a>
           </div>
           <div class="icon-row flexrow">
-            {{#each item.data.tags as |tag|}}
+            {{#each item.system.tags as |tag|}}
               {{#if (getTagIcon tag.value)}}
                 <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24"/>
               {{/if}}
             {{/each}}
-            {{#each item.data.tags as |tag|}}
+            {{#each item.system.tags as |tag|}}
             {{#unless (getTagIcon tag.value)}}
               <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
 
@@ -36,11 +36,11 @@
             {{/each}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.system.weight}}{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
-            <a class="item-control item-toggle {{#unless item.data.equipped}}item-unequipped{{/unless}}"
+            <a class="item-control item-toggle {{#unless item.system.equipped}}item-unequipped{{/unless}}"
               title='{{localize "OSE.items.Equip"}}'>
               <i class="fas fa-tshirt"></i>
             </a>
@@ -82,17 +82,17 @@
           </div>
           <div class="field-short">
             {{#if @root.config.ascendingAC}}
-            {{item.data.aac.value}}
+            {{item.system.aac.value}}
             {{else}}
-            {{item.data.ac.value}}
+            {{item.system.ac.value}}
             {{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.system.weight}}{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
-            <a class="item-control item-toggle {{#unless item.data.equipped}}item-unequipped{{/unless}}"
+            <a class="item-control item-toggle {{#unless item.system.equipped}}item-unequipped{{/unless}}"
               title='{{localize "OSE.items.Equip"}}'>
               <i class="fas fa-tshirt"></i>
             </a>
@@ -119,7 +119,7 @@
     </li>
     <ol class="item-list">
       {{#each owned.items as |item|}}
-      {{#unless item.data.treasure}}
+      {{#unless item.system.treasure}}
       <li class="item-entry">
         <div class="item flexrow" data-item-id="{{item._id}}">
           <div class="item-name flexrow">
@@ -131,11 +131,11 @@
             </a>
           </div>
           <div class="field-short quantity">
-            <input value="{{item.data.quantity.value}}" type="text"
-              placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
+            <input value="{{item.system.quantity.value}}" type="text"
+              placeholder="0" />{{#if item.system.quantity.max}}<span>/{{item.system.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance "detailed")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance "detailed")}}_{{else}}{{item.system.weight}}{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -154,7 +154,7 @@
     <li class="item-titles flexrow">
       <div class="item-caret"><i class="fas fa-caret-down"></i></div>
       <div class="item-name">{{localize "OSE.items.Treasure"}}</div>
-      <div class="field-long">{{data.treasure}} <i class="fas fa-circle"></i></div>
+      <div class="field-long">{{system.treasure}} <i class="fas fa-circle"></i></div>
       <div class="field-short"><i class="fas fa-hashtag"></i></div>
       <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
       <div class="item-controls">
@@ -164,7 +164,7 @@
     </li>
     <ol class="item-list">
       {{#each owned.items as |item|}}
-      {{#if item.data.treasure}}
+      {{#if item.system.treasure}}
       <li class="item-entry">
         <div class="item flexrow" data-item-id="{{item._id}}">
           <div class="item-name flexrow">
@@ -175,13 +175,13 @@
               </h4>
             </a>
           </div>
-          <div class="field-long">{{mult item.data.quantity.value item.data.cost}}</div>
+          <div class="field-long">{{mult item.system.quantity.value item.system.cost}}</div>
           <div class="field-short quantity">
-            <input value="{{item.data.quantity.value}}" type="text"
-              placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
+            <input value="{{item.system.quantity.value}}" type="text"
+              placeholder="0" />{{#if item.system.quantity.max}}<span>/{{item.system.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short">
-            {{mult item.data.quantity.value item.data.weight}}
+            {{mult item.system.quantity.value item.system.weight}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -197,7 +197,7 @@
   </div>
 </section>
 <section>
-  {{#with data.encumbrance}}
+  {{#with system.encumbrance}}
   <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
     <span class="encumbrance-bar" style="width:{{pct}}%"></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>

--- a/templates/actors/partials/character-notes-tab.html
+++ b/templates/actors/partials/character-notes-tab.html
@@ -12,7 +12,7 @@
                     </div>
                 </div>
                 <ol>
-                    {{#each data.languages.value as |lang|}}
+                    {{#each system.languages.value as |lang|}}
                     <li class="item flexrow" data-lang="{{lang}}">
                         <div class="item-name">
                             {{lang}}
@@ -28,7 +28,7 @@
             <div class="flex3 description">
                 <div class="item-titles">{{localize "OSE.category.description"}}</div>
                 <div>
-                    {{editor content=data.details.description target="data.details.description"
+                    {{editor content=system.details.description target="system.details.description"
                 button=true owner=owner editable=editable}}
                 </div>
             </div>
@@ -37,7 +37,7 @@
     <div class="inventory notes">
         <div class="item-titles">{{localize "OSE.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="140">
-            {{editor content=data.details.notes target="data.details.notes"
+            {{editor content=system.details.notes target="system.details.notes"
             button=true owner=owner editable=editable}}
         </div>
     </div>

--- a/templates/actors/partials/character-spells-tab.html
+++ b/templates/actors/partials/character-spells-tab.html
@@ -14,9 +14,9 @@
       <div class="item-name">{{localize "OSE.spells.Level"}} {{id}}</div>
       <div class="field-short">{{localize 'OSE.spells.Slots'}}</div>
       <div class="field-long flexrow">
-        <input type="text" value="{{lookup @root.slots.used @key}}" name="data.spells.{{id}}.value" data-dtype="Number"
-          placeholder="0" disabled>/<input type="text" value="{{lookup (lookup ../actor.data.spells @key) 'max'}}"
-          name="data.spells.{{id}}.max" data-dtype="Number" placeholder="0"></div>
+        <input type="text" value="{{lookup @root.slots.used @key}}" name="system.spells.{{id}}.value" data-dtype="Number"
+          placeholder="0" disabled>/<input type="text" value="{{lookup (lookup ../actor.system.spells @key) 'max'}}"
+          name="system.spells.{{id}}.max" data-dtype="Number" placeholder="0"></div>
       <div class="item-controls">
         <a class="item-control item-create" data-type="spell" data-lvl="{{id}}" title="{{localize 'OSE.Add'}}"><i
             class="fa fa-plus"></i></a>
@@ -35,10 +35,10 @@
             </a>
           </div>
           <div class="field-long memorize flexrow">
-            <input type="text" value="{{item.data.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
+            <input type="text" value="{{item.system.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
               title="{{localize 'OSE.spells.Cast'}}">
             /
-            <input type="text" value="{{item.data.memorized}}" data-field="memorize" data-dtype="Number" placeholder="0"
+            <input type="text" value="{{item.system.memorized}}" data-field="memorize" data-dtype="Number" placeholder="0"
               title="{{localize 'OSE.spells.Memorized'}}"></div>
           <div class="item-controls">
             {{#if ../../owner}}

--- a/templates/actors/partials/monster-attributes-tab.html
+++ b/templates/actors/partials/monster-attributes-tab.html
@@ -5,10 +5,10 @@
                 <h4 class="attribute-name box-title" title="{{localize 'OSE.Health'}}">{{ localize "OSE.HealthShort" }}
                     <a class="hp-roll"><i class="fas fa-dice"></i></a></h4>
                 <div class="attribute-value flexrow">
-                    <input name="data.hp.value" type="text" value="{{data.hp.value}}" data-dtype="Number"
+                    <input name="system.hp.value" type="text" value="{{system.hp.value}}" data-dtype="Number"
                         placeholder="0" />
                     <span class="sep"> / </span>
-                    <input name="data.hp.max" type="text" value="{{data.hp.max}}" data-dtype="Number" placeholder="0" />
+                    <input name="system.hp.max" type="text" value="{{system.hp.max}}" data-dtype="Number" placeholder="0" />
                 </div>
             </li>
             <li class="attribute hit-dice">
@@ -16,7 +16,7 @@
                     <a>{{ localize "OSE.HitDiceShort" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.hp.hd" type="text" value="{{data.hp.hd}}" data-dtype="String" />
+                    <input name="system.hp.hd" type="text" value="{{system.hp.hd}}" data-dtype="String" />
                 </div>
             </li>
             <li class="attribute">
@@ -24,14 +24,14 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.ArmorClass' }}">
                     {{ localize "OSE.AscArmorClassShort" }}</h4>
                 <div class="attribute-value">
-                    <input name="data.aac.value" type="text" value="{{data.aac.value}}" data-dtype="Number"
+                    <input name="system.aac.value" type="text" value="{{system.aac.value}}" data-dtype="Number"
                         placeholder="10" data-dtype="Number" />
                 </div>
                 {{else}}
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.ArmorClass' }}">
                     {{ localize "OSE.ArmorClassShort" }}</h4>
                 <div class="attribute-value">
-                    <input name="data.ac.value" type="text" value="{{data.ac.value}}" data-dtype="Number"
+                    <input name="system.ac.value" type="text" value="{{system.ac.value}}" data-dtype="Number"
                         placeholder="9" data-dtype="Number" />
                 </div>
                 {{/if}}
@@ -41,25 +41,25 @@
                 <h4 class="attribute-name box-title" title="{{localize 'OSE.AB'}}"><a>{{ localize "OSE.ABShort" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.thac0.bba" type="text" value="{{data.thac0.bba}}" placeholder="0"
+                    <input name="system.thac0.bba" type="text" value="{{system.thac0.bba}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 {{else}}
                 <h4 class="attribute-name box-title" title="{{localize 'OSE.Thac0'}}"><a>{{ localize "OSE.Thac0" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.thac0.value" type="text" value="{{data.thac0.value}}" placeholder="0"
+                    <input name="system.thac0.value" type="text" value="{{system.thac0.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 {{/if}}
             </li>
-            {{#if data.retainer.enabled}}
+            {{#if system.retainer.enabled}}
             <li class="attribute">
                 <h4 class="attribute-name box-title" title="{{ localize 'OSE.Loyalty' }}">
                     {{ localize "OSE.LoyaltyShort" }}
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.retainer.loyalty" type="text" value="{{data.retainer.loyalty}}" placeholder="0"
+                    <input name="system.retainer.loyalty" type="text" value="{{system.retainer.loyalty}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -69,7 +69,7 @@
                     {{ localize "OSE.movement.short" }}
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.movement.base" type="text" value="{{data.movement.base}}" placeholder="0"
+                    <input name="system.movement.base" type="text" value="{{system.movement.base}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -94,8 +94,8 @@
                     {{#each abilities as |item|}}
                     <li class="item-entry">
                         <div class="item flexrow" data-item-id="{{item._id}}">
-                            <div class="item-pattern" title="{{localize 'OSE.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.data.pattern}}, transparent)"></div>
-                            <div class="item-name {{#if item.data.roll}}item-rollable{{/if}} flexrow">
+                            <div class="item-pattern" title="{{localize 'OSE.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.system.pattern}}, transparent)"></div>
+                            <div class="item-name {{#if item.system.roll}}item-rollable{{/if}} flexrow">
                                 <div class="item-image" style="background-image: url({{item.img}})"></div>
                                 <h4 title="{{item.name}}">
                                     {{item.name~}}
@@ -119,7 +119,7 @@
                     <li class="item-entry">
                         <div class="item flexrow" data-item-id="{{item._id}}">
                             {{#if (eq item.type 'weapon')}}
-                            <div class="item-pattern" title="{{localize 'OSE.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.data.pattern}}, transparent)"></div>
+                            <div class="item-pattern" title="{{localize 'OSE.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.system.pattern}}, transparent)"></div>
                             {{/if}}
                             <div class="item-name {{#if (eq item.type 'weapon')}}item-rollable{{/if}}  flexrow">
                                 <div class="item-image" style="background-image: url({{item.img}})"></div>
@@ -129,10 +129,10 @@
                             </div>
                             {{#if (eq item.type 'weapon')}}
                             <div class="field-long counter flexrow">
-                                <input type="text" value="{{item.data.counter.value}}" data-dtype="Number"
+                                <input type="text" value="{{item.system.counter.value}}" data-dtype="Number"
                                     placeholder="0" data-field="value" title="{{localize 'OSE.items.roundAttacks'}}">
                                 /
-                                <input type="text" value="{{item.data.counter.max}}" data-field="max"
+                                <input type="text" value="{{item.system.counter.max}}" data-field="max"
                                     data-dtype="Number" placeholder="0"
                                     title="{{localize 'OSE.items.roundAttacksMax'}}"></div>
                             {{/if}}
@@ -156,7 +156,7 @@
             <ul class="attributes">
                 <li class="attacks-description">
                     <label>{{ localize "OSE.movement.details" }}</label>
-                    <input name="data.movement.value" type="text" value="{{data.movement.value}}" data-dtype="String" />
+                    <input name="system.movement.value" type="text" value="{{system.movement.value}}" data-dtype="String" />
                 </li>
                 <li>
                     <h4 class="attribute-name box-title">
@@ -168,9 +168,9 @@
                     <div class="attribute-value">
                     <input class="checkbox-round" 
                            type="checkbox" 
-                           name="data.saves.physical.value" 
+                           name="system.saves.physical.value" 
                            data-dtype="Boolean" 
-                           {{checked data.saves.physical.value}}/>
+                           {{checked system.saves.physical.value}}/>
                     </div>
                 </li>
                 <li class="attribute saving-throw" data-save="mental">
@@ -179,9 +179,9 @@
                     <div class="attribute-value">
                     <input class="checkbox-round" 
                            type="checkbox" 
-                           name="data.saves.mental.value" 
+                           name="system.saves.mental.value" 
                            data-dtype="Boolean" 
-                           {{checked data.saves.mental.value}}/>
+                           {{checked system.saves.mental.value}}/>
                     </div>
                 </li>
             </ul>

--- a/templates/actors/partials/monster-header.html
+++ b/templates/actors/partials/monster-header.html
@@ -6,20 +6,20 @@
   <ul class="summary flexrow">
     <li class="flexrow check-field">
       <div>
-        <input type="text" name="data.details.alignment" value="{{data.details.alignment}}" />
+        <input type="text" name="system.details.alignment" value="{{system.details.alignment}}" />
         <label>{{localize 'OSE.details.alignment'}}</label>
       </div>
       <div class="check reaction-check" title="{{localize 'OSE.roll.reaction'}}"><a><i class="fas fa-dice"></i></a></div>
     </li>
     <li class="flexrow check-field">
       <div>
-        <input type="text" name="data.details.type" value="{{data.details.type}}" />
+        <input type="text" name="system.details.type" value="{{system.details.type}}" />
         <label>{{localize 'OSE.details.type'}}</label>
       </div>
     </li>
     <li class="flexrow check-field" data-check="dungeon">
       <div>
-        <input type="text" name="data.details.appearing.d" value="{{data.details.appearing.d}}" />
+        <input type="text" name="system.details.appearing.d" value="{{system.details.appearing.d}}" />
         <label>{{localize 'OSE.details.appearing'}}</label>
       </div>
       <div class="check appearing-check" title="{{localize 'OSE.roll.appearing'}}"><a><i class="fas fa-dice"></i></a></div>
@@ -27,7 +27,7 @@
     {{#if config.morale}}
     <li class="flexrow check-field">
       <div>
-        <input type="text" name="data.details.morale" value="{{data.details.morale}}" />
+        <input type="text" name="system.details.morale" value="{{system.details.morale}}" />
         <label>{{localize 'OSE.details.morale'}}</label>  
       </div>
       <div class="check morale-check" title="{{localize 'OSE.roll.morale'}}"><a><i class="fas fa-dice"></i></a></div>
@@ -36,21 +36,21 @@
   </ul>
   <ul class="summary flexrow">
     <li>
-      <input type="text" name="data.details.size" value="{{data.details.size}}" />
+      <input type="text" name="system.details.size" value="{{system.details.size}}" />
       <label>{{localize 'OSE.details.experience.size'}}</label>
     </li>
     <li>
-      <input type="text" name="data.details.intelligence" value="{{data.details.intelligence}}" />
+      <input type="text" name="system.details.intelligence" value="{{system.details.intelligence}}" />
       <label>{{localize 'OSE.details.experience.intelligence'}}</label>
     </li>
   </ul>
   <ul class="summary flexrow">
     <li>
-      <input type="text" name="data.details.xp" value="{{data.details.xp}}" />
+      <input type="text" name="system.details.xp" value="{{system.details.xp}}" />
       <label>{{localize 'OSE.details.experience.award'}}</label>
     </li>
     <li>
-      <input type="text" name="data.details.treasure.value" value="{{data.details.treasure.value}}" />
+      <input type="text" name="system.details.treasure.value" value="{{system.details.treasure.value}}" />
       <label>{{localize 'OSE.details.treasure.value'}}</label>
     </li>
   </ul>

--- a/templates/apps/party-select.html
+++ b/templates/apps/party-select.html
@@ -4,7 +4,7 @@
         <li class="form-group actor" data-actor-id="{{actor.id}}">
             <label>{{actor.name}}</label>
             <div class="form-fields">
-                <input type="checkbox" data-action="select-actor" name="{{key}}" data-dtype="Boolean" {{checked actor.data.flags.ose.party}}/>
+                <input type="checkbox" data-action="select-actor" name="{{key}}" data-dtype="Boolean" {{checked actor.flags.ose.party}}/>
             </div>
         </li>
     {{/each}}

--- a/templates/apps/party-sheet.html
+++ b/templates/apps/party-sheet.html
@@ -15,7 +15,7 @@
     {{/if}}
   </div>
   <ol class="actor-list">
-    {{#each data.entities as |e|}} {{#if e.data.flags.ose.party}}
+    {{#each data.entities as |e|}} {{#if e.flags.ose.party}}
     <li class="actor flexrow" data-actor-id="{{e.id}}">
       <div class="field-img">
         <img src="{{e.img}}" />
@@ -30,13 +30,13 @@
           </div>
           <div class="field-long" title="{{localize 'OSE.Health'}}">
             <i class="fas fa-heart"></i>
-            {{e.data.data.hp.value}}/{{e.data.data.hp.max}}
+            {{e.system.hp.value}}/{{e.system.hp.max}}
           </div>
           <div class="field-short" title="{{localize 'OSE.ArmorClass'}}">
             <i class="fas fa-shield-alt"></i>
-            {{#if @root.settings.ascending}}<strong>{{e.data.data.aac.value}}</strong>
-            <sub>{{e.data.data.aac.naked}}</sub>
-            {{else}}<strong>{{e.data.data.ac.value}}</strong> <sub>{{e.data.data.ac.naked}}</sub>
+            {{#if @root.settings.ascending}}<strong>{{e.system.aac.value}}</strong>
+            <sub>{{e.system.aac.naked}}</sub>
+            {{else}}<strong>{{e.system.ac.value}}</strong> <sub>{{e.system.ac.naked}}</sub>
             {{/if}}
           </div>
         </div>
@@ -44,40 +44,40 @@
           <div class="field-short" title="{{localize 'OSE.Thac0'}}">
             <i class="fas fa-crosshairs"></i>
             {{#unless settings.ascendingAC}}
-            {{e.data.data.thac0.value}}
+            {{e.system.thac0.value}}
             {{else}}
-            {{e.data.data.thac0.bba}}
+            {{e.system.thac0.bba}}
             {{/unless}}
           </div>
-          {{#if (eq e.data.type 'character')}}
+          {{#if (eq e.type 'character')}}
           <div class="field-short" title="{{localize 'OSE.Melee'}}">
             <i class="fas fa-fist-raised"></i>
-            {{add e.data.data.scores.str.mod e.data.data.thac0.mod.melee}}
+            {{add e.system.scores.str.mod e.system.thac0.mod.melee}}
           </div>
           <div class="field-short" title="{{localize 'OSE.Missile'}}">
             <i class="fas fa-bullseye"></i>
-            {{add e.data.data.scores.dex.mod e.data.data.thac0.mod.missile}}
+            {{add e.system.scores.dex.mod e.system.thac0.mod.missile}}
           </div>
           {{/if}}
           <div class="field-short flex2">
             <i class="fas fa-shoe-prints" title="{{localize 'OSE.movement.base'}}"></i>
-            <span title="{{localize 'OSE.movement.encounter.long'}}">{{e.data.data.movement.encounter}}</span> <sub
-              title="{{localize 'OSE.movement.exploration.long'}}">{{e.data.data.movement.base}}</sub>
+            <span title="{{localize 'OSE.movement.encounter.long'}}">{{e.system.movement.encounter}}</span> <sub
+              title="{{localize 'OSE.movement.exploration.long'}}">{{e.system.movement.base}}</sub>
           </div>
-          {{#if (eq e.data.type 'character')}}
+          {{#if (eq e.type 'character')}}
           <div class="field-short flex2">
             <i class="fas fa-weight-hanging" title="{{localize 'OSE.Encumbrance'}}"></i>
-            {{roundWeight e.data.data.encumbrance.value}}k
+            {{roundWeight e.system.encumbrance.value}}k
           </div>
           {{/if}}
         </div>
         <div class="flexrow field-row">
           <div class="field-longer flexrow">
-            {{#each e.data.data.saves as |s i|}}
+            {{#each e.system.saves as |s i|}}
             <span title="{{lookup @root.config.saves_long i}}">{{lookup @root.config.saves_short i}} {{s.value}}</span>
             {{/each}}
-            {{#if (eq e.data.type 'character')}}<span><i class="fas fa-magic"
-                title="{{localize 'OSE.saves.magic.long'}}"></i>{{mod e.data.data.scores.wis.mod}}</span>{{/if}}
+          {{#if (eq e.type 'character')}}<span><i class="fas fa-magic"
+                title="{{localize 'OSE.saves.magic.long'}}"></i>{{mod e.system.scores.wis.mod}}</span>{{/if}}
           </div>
         </div>
       </div>

--- a/templates/items/ability-sheet.html
+++ b/templates/items/ability-sheet.html
@@ -13,20 +13,20 @@
         <div class="form-group block-input">
           <label>{{localize 'OSE.abilities.Requirements'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.requirements" value="{{data.requirements}}" data-dtype="String" />
+            <input type="text" name="system.requirements" value="{{system.requirements}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.roll}}" data-dtype="String" />
+            <input type="text" name="system.roll" value="{{system.roll}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.RollType'}}</label>
           <div class="form-fields">
-            <select name="data.rollType">
-              {{#select data.rollType}}
+            <select name="system.rollType">
+              {{#select system.rollType}}
               {{#each config.roll_type as |t a|}}
               <option value="{{a}}">{{t}}</option>
               {{/each}}
@@ -37,20 +37,20 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.RollTarget'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.rollTarget" value="{{data.rollTarget}}" data-dtype="Number" />
+            <input type="text" name="system.rollTarget" value="{{system.rollTarget}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.BlindRoll'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="data.blindroll" value="{{data.blindroll}}" {{checked data.blindroll}}  data-dtype="Number"/>
+            <input type="checkbox" name="system.blindroll" value="{{system.blindroll}}" {{checked system.blindroll}}  data-dtype="Number"/>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
+            <select name="system.save">
+              {{#select system.save}}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -61,7 +61,7 @@
         </div>
       </div>
       <div class="description">
-        {{editor content=data.description target="data.description" button=true
+        {{editor content=system.description target="system.description" button=true
         owner=owner editable=editable}}
       </div>
     </div>

--- a/templates/items/armor-sheet.html
+++ b/templates/items/armor-sheet.html
@@ -14,21 +14,21 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.ArmorAC'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.ac.value" value="{{data.ac.value}}" data-dtype="Number" />
+            <input type="text" name="system.ac.value" value="{{system.ac.value}}" data-dtype="Number" />
           </div>
         </div>
         -->
         <div class="form-group">
           <label>{{localize 'OSE.items.ArmorAAC'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.aac.value" value="{{data.aac.value}}" data-dtype="Number" />
+            <input type="text" name="system.aac.value" value="{{system.aac.value}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.armor.type'}}</label>
           <div class="form-fields">
-            <select name="data.type">
-              {{#select data.type}}
+            <select name="system.type">
+              {{#select system.type}}
               <option value=""></option>
               {{#each config.armor as |armor a|}}
               <option value="{{a}}">{{armor}}</option>
@@ -40,18 +40,18 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
+            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
+            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor content=data.description target="data.description" button=true
+        {{editor content=system.description target="system.description" button=true
         owner=owner editable=editable}}
       </div>
     </div>

--- a/templates/items/item-sheet.html
+++ b/templates/items/item-sheet.html
@@ -13,30 +13,30 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.Quantity'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.quantity.value" value="{{data.quantity.value}}" data-dtype="Number" />/<input type="text" name="data.quantity.max" value="{{data.quantity.max}}" data-dtype="Number" />
+            <input type="text" name="system.quantity.value" value="{{system.quantity.value}}" data-dtype="Number" />/<input type="text" name="system.quantity.max" value="{{system.quantity.max}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Treasure'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="data.treasure" value="{{data.treasure}}" {{checked data.treasure}}  data-dtype="Boolean"/>
+            <input type="checkbox" name="system.treasure" value="{{system.treasure}}" {{checked system.treasure}}  data-dtype="Boolean"/>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
+            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
+            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor content=data.description target="data.description" button=true
+        {{editor content=system.description target="system.description" button=true
         owner=owner editable=editable}}
       </div>
     </div>

--- a/templates/items/spell-sheet.html
+++ b/templates/items/spell-sheet.html
@@ -13,32 +13,32 @@
         <div class="form-group">
           <label>{{localize 'OSE.spells.Level'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.lvl" value="{{data.lvl}}" data-dtype="Number" />
+            <input type="text" name="system.lvl" value="{{system.lvl}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Class'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.class" value="{{data.class}}" data-dtype="String" />
+            <input type="text" name="system.class" value="{{system.class}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Duration'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.duration" value="{{data.duration}}" data-dtype="String" />
+            <input type="text" name="system.duration" value="{{system.duration}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Range'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.range" value="{{data.range}}" data-dtype="String" />
+            <input type="text" name="system.range" value="{{system.range}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
+            <select name="system.save">
+              {{#select system.save}}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -50,12 +50,12 @@
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.roll}}" data-dtype="String" />
+            <input type="text" name="system.roll" value="{{system.roll}}" data-dtype="String" />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor content=data.description target="data.description" button=true
+        {{editor content=system.description target="system.description" button=true
         owner=owner editable=editable}}
       </div>
     </div>

--- a/templates/items/weapon-sheet.html
+++ b/templates/items/weapon-sheet.html
@@ -23,8 +23,8 @@
             <div class="form-fields">
               <input
                 type="text"
-                name="data.cost"
-                value="{{data.cost}}"
+                name="system.cost"
+                value="{{system.cost}}"
                 data-dtype="Number"
                 />
             </div>
@@ -35,8 +35,8 @@
             <div class="form-fields">
               <input
                 type="text"
-                name="data.weight"
-                value="{{data.weight}}"
+                name="system.weight"
+                value="{{system.weight}}"
                 data-dtype="Number"
                 />
             </div>
@@ -44,7 +44,7 @@
         </div>
       </div>
       <ol class="tag-list">
-        {{#each data.tags as |tag|}}
+        {{#each system.tags as |tag|}}
         <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
           <span>{{tag.value}}</span>
           <a class="tag-delete"><i class="fas fa-times"></i></a>
@@ -71,8 +71,8 @@
           <div class="form-fields">
             <input
               type="text"
-              name="data.damage"
-              value="{{data.damage}}"
+              name="system.damage"
+              value="{{system.damage}}"
               data-dtype="String"
               />
           </div>
@@ -83,40 +83,40 @@
           <div class="form-fields">
             <input
               type="text"
-              name="data.bonus"
-              value="{{data.bonus}}"
+              name="system.bonus"
+              value="{{system.bonus}}"
               data-dtype="Number"
               />
           </div>
         </div>
         <div class="form-group attack-type">
           <a title="{{localize 'OSE.items.Melee'}}" class="melee-toggle {{#if
-            data.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
+            system.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
           <a title="{{localize 'OSE.items.Missile'}}" class="missile-toggle
-            {{#if data.missile}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
+            {{#if system.missile}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
         </div>
-        {{#if data.missile}}
+        {{#if system.missile}}
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Range'}}</label>
           <div class="form-fields range">
             <input
               type="text"
-              name="data.range.short"
-              value="{{data.range.short}}"
+              name="system.range.short"
+              value="{{system.range.short}}"
               data-dtype="Number"
               />
               <div class="sep"></div>
               <input
               type="text"
-              name="data.range.medium"
-              value="{{data.range.medium}}"
+              name="system.range.medium"
+              value="{{system.range.medium}}"
               data-dtype="Number"
               />
               <div class="sep"></div>
               <input
               type="text"
-              name="data.range.long"
-              value="{{data.range.long}}"
+              name="system.range.long"
+              value="{{system.range.long}}"
               data-dtype="Number"
               />
           </div>
@@ -125,8 +125,8 @@
         <div class="form-group">
           <label>{{localize 'OSE.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
+            <select name="system.save">
+              {{#select system.save}}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -140,17 +140,17 @@
           <div class="form-fields">
             <input
               type="checkbox"
-              name="data.slow"
-              value="{{data.slow}}"
+              name="system.slow"
+              value="{{system.slow}}"
               {{checked
-              data.slow}}
+              system.slow}}
               data-dtype="Number"
               />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor content=data.description target="data.description" button=true
+        {{editor content=system.description target="system.description" button=true
         owner=owner editable=editable}}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update actor and item sheets to use `system` data
- migrate item creation and updates to `createEmbeddedDocuments` API
- replace deprecated data paths across all templates

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ff66120448330bb166de58db08c82